### PR TITLE
chore: upgrade calcit to 0.13.27

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: calcit-lang/setup-cr@0.0.9
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,9 +12,9 @@ dependencies = [
 
 [[package]]
 name = "cirru_edn"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a3d754e1ea42cbeffaa32f3e3a80f32a709e935c697d716a89423975c9c7653"
+checksum = "7f9a574a5164698fdd0881368444c47fad4b3188f82898386b9f28b83d9626d7"
 dependencies = [
  "cirru_parser",
  "cjk",
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "cirru_parser"
-version = "0.2.8"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c653542a798accd63a555315805cc54f25075e927e2cd893ba1f5662107252"
+checksum = "91044eb215dc0a2a75af6d3955f0074a4e7024ed4608a3be812024a950bb4e73"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["dylib"] # Creates dynamic lib
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_edn = "0.7.7"
+cirru_edn = "0.8.0"
 cirru_parser = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["dylib"] # Creates dynamic lib
 
 [dependencies]
 cirru_edn = "0.8.0"
-cirru_parser = "0.2.8"
+cirru_parser = "=0.2.15"

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,4 @@
 
-{} (:calcit-version |0.13.19)
+{} (:calcit-version |0.13.27)
+  :version |0.0.1
   :dependencies $ {}

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{}
-  :calcit-version |0.12.35
+{} (:calcit-version |0.13.19)
+  :dependencies $ {}


### PR DESCRIPTION
Per `cr docs read upgrade`: `caps upgrade --all` -> `:calcit-version` 0.13.19, deps bumped to latest tags, `@calcit/procs` synced to ^0.13.19. Branch based on `main`; local feature-branch state untouched.