### PR TITLE
upgrade dylib-workflow to 0.13.29

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: calcit-lang/setup-cr@0.0.9
+      - uses: calcit-lang/setup-calcit@v1
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -29,4 +29,4 @@ jobs:
 
       - run: mkdir -p dylibs/ && ls target/release/ && cp -v target/release/*.* dylibs/
 
-      - run: cr calcit.cirru
+      - run: calcit calcit.cirru

--- a/Agents.md
+++ b/Agents.md
@@ -1,68 +1,14 @@
-## dylib-workflow 开发说明
+# Agent notes
 
-### 关键步骤
+This repository provides a native Calcit dynamic-library workflow. Keep project notes short and use maintained CLI documentation.
 
-1. **升级依赖版本**
-   - 在 `Cargo.toml` 中保持与当前 Calcit 运行时兼容：
-     - `cirru_edn = "0.7.3"`
-     - `cirru_parser = "0.2.3"`
-   - 当前工程使用 `edition = "2024"`。
+```bash
+calcit docs agents --full
+calcit docs read upgrade --full
+caps --ci
+calcit calcit.cirru edit format
+calcit calcit.cirru --check-only
+```
 
-2. **保持 FFI 导出接口完整**
-   - 所有导出函数使用 `#[unsafe(no_mangle)]`。
-   - 至少导出以下函数：
-     - `abi_version() -> String`
-     - `edn_version() -> String`
-   - `edn_version()` 需要返回：
-     - `cirru_edn::version().to_string()`
+The canonical snapshot is `calcit.cirru`; do not use or add `compact.cirru`. Use `calcit`, not the retired `cr` command. Build the native library with the repository's `build.sh` after the Calcit check passes.
 
-3. **业务函数签名**
-   - Calcit 侧通过 `&call-dylib-edn` 调用 Rust 导出函数。
-   - Rust 侧函数保持形如：
-     - `pub fn path_exists(args: Vec<Edn>) -> Result<Edn, String>`
-   - 参数数量和类型检查在 Rust 内部显式处理，错误信息直接返回字符串。
-
-4. **构建动态库**
-   - 在项目根目录执行：
-     - `cargo build --release`
-   - 产物位于 `target/release/`。
-
-5. **刷新运行时 dylib 文件**
-   - 清理并复制产物到 `dylibs/`：
-     - `rm -rf dylibs/*`
-     - `mkdir -p dylibs`
-     - `cp target/release/*.* dylibs/`
-   - Calcit 示例默认从 `dylibs/libcalcit_std` 加载动态库。
-
-6. **运行 Calcit 示例验证**
-   - 执行：
-     - `cr compact.cirru`
-   - 当前预期输出应包含：
-     - `%%%% test for lib`
-     - `true false`
-     - 最后返回 `nil`
-
-### 修改时的检查清单
-
-- 修改导出函数后，先确认 Rust 侧可以成功编译。
-- 如果运行 `cr compact.cirru` 报 `dlsym failed`：
-  - 先检查是否漏导出了 `edn_version`
-  - 再检查 `#[unsafe(no_mangle)]` 是否遗漏
-  - 再确认 `dylibs/` 中已复制最新产物
-- 如果只更新了 `target/release/` 但没有同步到 `dylibs/`，Calcit 仍会加载旧库。
-
-### 推荐验证流程
-
-按顺序执行：
-
-1. 修改 `Cargo.toml` / `src/lib.rs`
-2. `cargo build --release`
-3. 复制 `target/release/*.*` 到 `dylibs/`
-4. `cr compact.cirru`
-
-### 当前已验证状态
-
-- 依赖版本已升级到 `cirru_edn 0.7.3`、`cirru_parser 0.2.3`
-- FFI 已补充 `edn_version()`
-- Rust 2024 下导出属性已切换为 `#[unsafe(no_mangle)]`
-- `cr compact.cirru` 已验证通过

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |lib)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |lib)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'lib.test/main!) (:mode :native) (:reload-fn 'lib.test/reload!)
       :feature-policy $ {}

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.27)
+{} (:calcit-version |0.13.29)
   :version |0.0.1
   :dependencies $ {}

--- a/history/2026082221-upgrade-calcit-01329.md
+++ b/history/2026082221-upgrade-calcit-01329.md
@@ -1,0 +1,5 @@
+2026-08-22 21:00 — Upgrade dylib workflow toolchain
+
+- Updated the Calcit toolchain to 0.13.29 and setup-calcit.
+- Replaced the workflow's remaining `cr` command with `calcit`.
+- Verified Rust fmt/clippy/test/release build and Calcit check-only.


### PR DESCRIPTION
Synced latest main before this change. Upgrades the project to Calcit 0.13.29, uses setup-calcit/calcit, and keeps calcit.cirru as the canonical snapshot. The project-local copied CLI/baseline infrastructure was replaced with maintained Calcit docs or native quality tooling where applicable.\n\nLocal validation completed with the repository's Rust checks and Calcit check-only/codegen commands.